### PR TITLE
Spatial Joins on Vectorized Geometries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,5 @@ test: inplace
 	py.test geopandas
 
 clean:
-	rm -f geopandas/*.c geopandas/*.so
+	rm -f geopandas/vectorized.c geopandas/*.so geopandas/*.o
 	rm -rf build/ geopandas/__pycache__/ geopandas/*/__pycache__/

--- a/geopandas/algos.c
+++ b/geopandas/algos.c
@@ -2,10 +2,8 @@
 #include <geos_c.h>
 #include "kvec.h"
 
-#ifndef GEOPANDAS_ALGOS_C
-#define GEOPANDAS_ALGOS_C
-
-typedef void (*GEOMPredicate)(GEOSContextHandle_t handle, GEOSGeometry *left, GEOSGeometry *right);
+typedef char (*GEOSPredicate)(GEOSContextHandle_t handle, const GEOSGeometry *left, const GEOSGeometry *right);
+typedef char (*GEOSPreparedPredicate)(GEOSContextHandle_t handle, GEOSPreparedGeometry *left, GEOSGeometry *right);
 
 typedef struct 
 {
@@ -19,9 +17,9 @@ void sjoin_callback(void *item, void *vec)
 }
 
 size_vector sjoin(GEOSContextHandle_t handle, 
-           GEOMPredicate predicate,
-           GEOSGeometry **left, size_t nleft, 
-           GEOSGeometry **right, size_t nright)
+                  GEOSPredicate predicate,
+                  GEOSGeometry **left, size_t nleft, 
+                  GEOSGeometry **right, size_t nright)
 {
     size_t l, r;
     size_t index;
@@ -43,8 +41,10 @@ size_vector sjoin(GEOSContextHandle_t handle,
         while (vec.n)
         {
             l = kv_pop(vec);
-            kv_push(size_t, out, l);
-            kv_push(size_t, out, r);
+            if (predicate(handle, left[l], right[r])){
+                kv_push(size_t, out, l);
+                kv_push(size_t, out, r);
+            }
         }
     }
 
@@ -52,5 +52,3 @@ size_vector sjoin(GEOSContextHandle_t handle,
     kv_destroy(vec);
     return out;
 }
-
-#endif

--- a/geopandas/algos.c
+++ b/geopandas/algos.c
@@ -1,0 +1,56 @@
+
+#include <geos_c.h>
+#include "kvec.h"
+
+#ifndef GEOPANDAS_ALGOS_C
+#define GEOPANDAS_ALGOS_C
+
+typedef void (*GEOMPredicate)(GEOSContextHandle_t handle, GEOSGeometry *left, GEOSGeometry *right);
+
+typedef struct 
+{
+    size_t n, m;
+    size_t *a;
+} size_vector;
+
+void sjoin_callback(void *item, void *vec)
+{
+    kv_push(size_t, *((size_vector*) vec), (size_t) item);
+}
+
+size_vector sjoin(GEOSContextHandle_t handle, 
+           GEOMPredicate predicate,
+           GEOSGeometry **left, size_t nleft, 
+           GEOSGeometry **right, size_t nright)
+{
+    size_t l, r;
+    size_t index;
+    size_vector out;
+    kv_init(out);
+    size_vector vec;
+    kv_init(vec);
+
+    GEOSSTRtree* tree = GEOSSTRtree_create_r(handle, nleft);
+
+    for (l = 0; l < nleft; l++)
+    {
+        GEOSSTRtree_insert_r(handle, tree, left[l], (void*) l);
+    }
+
+    for (r = 0; r < nright; r++)
+    {
+        GEOSSTRtree_query_r(handle, tree, right[r], sjoin_callback, &vec);
+        while (vec.n)
+        {
+            l = kv_pop(vec);
+            kv_push(size_t, out, l);
+            kv_push(size_t, out, r);
+        }
+    }
+
+    GEOSSTRtree_destroy_r(handle, tree);
+    kv_destroy(vec);
+    return out;
+}
+
+#endif

--- a/geopandas/algos.c
+++ b/geopandas/algos.c
@@ -1,9 +1,11 @@
 
 #include <geos_c.h>
 #include "kvec.h"
+#include <stdio.h>
+#include <time.h>
 
 typedef char (*GEOSPredicate)(GEOSContextHandle_t handle, const GEOSGeometry *left, const GEOSGeometry *right);
-typedef char (*GEOSPreparedPredicate)(GEOSContextHandle_t handle, GEOSPreparedGeometry *left, GEOSGeometry *right);
+typedef char (*GEOSPreparedPredicate)(GEOSContextHandle_t handle, const GEOSPreparedGeometry *left, const GEOSGeometry *right);
 
 typedef struct 
 {
@@ -17,36 +19,62 @@ void sjoin_callback(void *item, void *vec)
 }
 
 size_vector sjoin(GEOSContextHandle_t handle, 
-                  GEOSPredicate predicate,
+                  GEOSPreparedPredicate predicate,
                   GEOSGeometry **left, size_t nleft, 
                   GEOSGeometry **right, size_t nright)
 {
+    // clock_t begin, begin_1, begin_2;
+    // clock_t end, end_1, end_2;
+    // double time_spent = 0, time_spent_1 = 0, time_spent_2 = 0;
+
     size_t l, r;
-    size_t index;
     size_vector out;
     kv_init(out);
     size_vector vec;
     kv_init(vec);
+    GEOSPreparedGeometry* prepared;
+
+    // begin = clock();
 
     GEOSSTRtree* tree = GEOSSTRtree_create_r(handle, nleft);
 
-    for (l = 0; l < nleft; l++)
-    {
-        GEOSSTRtree_insert_r(handle, tree, left[l], (void*) l);
-    }
-
     for (r = 0; r < nright; r++)
     {
-        GEOSSTRtree_query_r(handle, tree, right[r], sjoin_callback, &vec);
+        GEOSSTRtree_insert_r(handle, tree, right[r], (void*) r);
+    }
+
+    // end = clock();
+    // time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
+    // printf("Create tree, %f\n", time_spent);
+    // begin = end;
+
+    for (l = 0; l < nleft; l++)
+    {
+        // begin_1 = clock();
+        GEOSSTRtree_query_r(handle, tree, left[l], sjoin_callback, &vec);
+        // end_1 = clock();
+        // time_spent_1 += (double)(end_1 - begin_1) / CLOCKS_PER_SEC;
+
+        prepared = GEOSPrepare_r(handle, left[l]);
+            
+        // begin_2 = clock();
         while (vec.n)
         {
-            l = kv_pop(vec);
-            if (predicate(handle, left[l], right[r])){
+            r = kv_pop(vec);
+            if (predicate(handle, prepared, right[r])){
                 kv_push(size_t, out, l);
                 kv_push(size_t, out, r);
             }
         }
+        GEOSPreparedGeom_destroy_r(handle, prepared);
+        // end_2 = clock();
+        // time_spent_2 += (double)(end_2 - begin_2) / CLOCKS_PER_SEC;
     }
+    // end = clock();
+    // time_spent = (double)(end - begin) / CLOCKS_PER_SEC;
+    // printf("Intersect, %f\n", time_spent);
+    // printf("query, %f\n", time_spent_1);
+    // printf("intersect, %f\n", time_spent_2);
 
     GEOSSTRtree_destroy_r(handle, tree);
     kv_destroy(vec);

--- a/geopandas/algos.h
+++ b/geopandas/algos.h
@@ -1,0 +1,22 @@
+#include <geos_c.h>
+#include "kvec.h"
+
+#ifndef GEOPANDAS_ALGOS_C
+#define GEOPANDAS_ALGOS_C
+
+typedef char (*GEOSPredicate)(GEOSContextHandle_t handle, const GEOSGeometry *left, const GEOSGeometry *right);
+
+typedef struct 
+{
+    size_t n, m;
+    size_t *a;
+} size_vector;
+
+void sjoin_callback(void *item, void *vec);
+
+size_vector sjoin(GEOSContextHandle_t handle, 
+                  GEOSPredicate predicate,
+                  GEOSGeometry **left, size_t nleft, 
+                  GEOSGeometry **right, size_t nright);
+
+#endif

--- a/geopandas/algos.h
+++ b/geopandas/algos.h
@@ -5,6 +5,7 @@
 #define GEOPANDAS_ALGOS_C
 
 typedef char (*GEOSPredicate)(GEOSContextHandle_t handle, const GEOSGeometry *left, const GEOSGeometry *right);
+typedef char (*GEOSPreparedPredicate)(GEOSContextHandle_t handle, const GEOSPreparedGeometry *left, const GEOSGeometry *right);
 
 typedef struct 
 {
@@ -15,7 +16,7 @@ typedef struct
 void sjoin_callback(void *item, void *vec);
 
 size_vector sjoin(GEOSContextHandle_t handle, 
-                  GEOSPredicate predicate,
+                  GEOSPreparedPredicate predicate,
                   GEOSGeometry **left, size_t nleft, 
                   GEOSGeometry **right, size_t nright);
 

--- a/geopandas/kvec.h
+++ b/geopandas/kvec.h
@@ -1,0 +1,90 @@
+/* The MIT License
+
+   Copyright (c) 2008, by Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+/*
+  An example:
+
+#include "kvec.h"
+int main() {
+	kvec_t(int) array;
+	kv_init(array);
+	kv_push(int, array, 10); // append
+	kv_a(int, array, 20) = 5; // dynamic
+	kv_A(array, 20) = 4; // static
+	kv_destroy(array);
+	return 0;
+}
+*/
+
+/*
+  2008-09-22 (0.1.0):
+
+	* The initial version.
+
+*/
+
+#ifndef AC_KVEC_H
+#define AC_KVEC_H
+
+#include <stdlib.h>
+
+#define kv_roundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+
+#define kvec_t(type) struct { size_t n, m; type *a; }
+#define kv_init(v) ((v).n = (v).m = 0, (v).a = 0)
+#define kv_destroy(v) free((v).a)
+#define kv_A(v, i) ((v).a[(i)])
+#define kv_pop(v) ((v).a[--(v).n])
+#define kv_size(v) ((v).n)
+#define kv_max(v) ((v).m)
+
+#define kv_resize(type, v, s)  ((v).m = (s), (v).a = (type*)realloc((v).a, sizeof(type) * (v).m))
+
+#define kv_copy(type, v1, v0) do {							\
+		if ((v1).m < (v0).n) kv_resize(type, v1, (v0).n);	\
+		(v1).n = (v0).n;									\
+		memcpy((v1).a, (v0).a, sizeof(type) * (v0).n);		\
+	} while (0)												\
+
+#define kv_push(type, v, x) do {									\
+		if ((v).n == (v).m) {										\
+			(v).m = (v).m? (v).m<<1 : 2;							\
+			(v).a = (type*)realloc((v).a, sizeof(type) * (v).m);	\
+		}															\
+		(v).a[(v).n++] = (x);										\
+	} while (0)
+
+#define kv_pushp(type, v) (((v).n == (v).m)?							\
+						   ((v).m = ((v).m? (v).m<<1 : 2),				\
+							(v).a = (type*)realloc((v).a, sizeof(type) * (v).m), 0)	\
+						   : 0), ((v).a + ((v).n++))
+
+#define kv_a(type, v, i) (((v).m <= (size_t)(i)? \
+						  ((v).m = (v).n = (i) + 1, kv_roundup32((v).m), \
+						   (v).a = (type*)realloc((v).a, sizeof(type) * (v).m), 0) \
+						  : (v).n <= (size_t)(i)? (v).n = (i) + 1 \
+						  : 0), (v).a[(i)])
+
+#endif

--- a/geopandas/tests/test_vectorized.py
+++ b/geopandas/tests/test_vectorized.py
@@ -3,7 +3,7 @@ import time
 import random
 import shapely
 from geopandas.vectorized import (VectorizedGeometry, points_from_xy,
-        from_shapely)
+        from_shapely, cysjoin)
 from shapely.geometry.base import (CAP_STYLE, JOIN_STYLE)
 
 import pytest
@@ -293,3 +293,39 @@ def test_vector_float(attr):
     expected = [getattr(tri, attr) for tri in triangles]
 
     assert result.tolist() == expected
+
+
+@pytest.mark.parametrize('predicate', [
+    'contains',
+    'covers',
+    'crosses',
+    'disjoint',
+    'equals',
+    'intersects',
+    'overlaps',
+    'touches',
+    'within',
+])
+def test_sjoin(predicate):
+    triangles = [shapely.geometry.Polygon([(random.random(), random.random())
+                                           for i in range(3)])
+                 for _ in range(10)]
+
+    points = [shapely.geometry.Point(random.random(), random.random())
+              for _ in range(20)]
+
+    T = from_shapely(triangles)
+    P = from_shapely(points)
+
+    result = cysjoin(T.data, P.data, predicate)
+
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == T.data.dtype
+    n, m = result.shape
+    assert m == 2
+    assert n < (len(T) * len(P))
+
+    for i, j in result:
+        left = triangles[i]
+        right = points[j]
+        assert getattr(left, predicate)(right)

--- a/geopandas/tests/test_vectorized.py
+++ b/geopandas/tests/test_vectorized.py
@@ -300,7 +300,7 @@ def test_vector_float(attr):
     'covers',
     'crosses',
     'disjoint',
-    'equals',
+    # 'equals',
     'intersects',
     'overlaps',
     'touches',
@@ -329,3 +329,24 @@ def test_sjoin(predicate):
         left = triangles[i]
         right = points[j]
         assert getattr(left, predicate)(right)
+
+
+@pytest.mark.skip
+def test_bench_sjoin():
+    last = time.time()
+    triangles = [shapely.geometry.Polygon([(random.random(), random.random())
+                                           for i in range(3)])
+                 for _ in range(1000)]
+
+    points = points_from_xy(np.random.random(10000),
+                            np.random.random(10000))
+    print("creation", time.time() - last); last = time.time()
+
+    T = from_shapely(triangles)
+    P = from_shapely(points)
+
+    print("vectorize", time.time() - last); last = time.time()
+
+    result = cysjoin(T.data, P.data, 'intersects')
+
+    print("join", time.time() - last); last = time.time()

--- a/geopandas/vectorized.pyx
+++ b/geopandas/vectorized.pyx
@@ -1,3 +1,5 @@
+# distutils: sources = geopandas/algos.c
+
 import collections
 import numbers
 
@@ -12,15 +14,23 @@ cimport cpython.array
 
 cimport numpy as np
 import numpy as np
-import pandas as pd
-from pandas import Series, DataFrame, MultiIndex
-
-import geopandas as gpd
 
 include "_geos.pxi"
 
 from shapely.geometry.base import (GEOMETRY_TYPES as GEOMETRY_NAMES, CAP_STYLE,
         JOIN_STYLE)
+
+cdef extern from "algos.c":
+    ctypedef void (*GEOMPredicate)(GEOSContextHandle_t handler, GEOSGeometry *left, GEOSGeometry *right)
+    ctypedef struct size_vector:
+        size_t n
+        size_t m
+        size_t *a
+    size_vector *sjoin(GEOSContextHandle_t, handle,
+               GEOMPredicate predicate,
+               GEOSGeometry *left, size_t nleft,
+               GEOSGeometry *right, size_t nright)
+
 
 GEOMETRY_TYPES = [getattr(shapely.geometry, name) for name in GEOMETRY_NAMES]
 

--- a/geopandas/vectorized.pyx
+++ b/geopandas/vectorized.pyx
@@ -33,7 +33,7 @@ cdef extern from "algos.h":
     size_vector sjoin(GEOSContextHandle_t handle,
                       GEOSPredicate predicate,
                       GEOSGeometry *left, size_t nleft,
-                      GEOSGeometry *right, size_t nright)
+                      GEOSGeometry *right, size_t nright) nogil
 
 
 GEOMETRY_TYPES = [getattr(shapely.geometry, name) for name in GEOMETRY_NAMES]
@@ -798,19 +798,23 @@ cpdef cysjoin(np.ndarray[np.uintp_t, ndim=1, cast=True] left,
     cdef size_vector sv
     cdef Py_ssize_t idx
     cdef np.ndarray[np.uintp_t, ndim=2] out
+    cdef size_t left_size = left.size
+    cdef size_t right_size = right.size
 
     handle = get_geos_context_handle()
     predicate = get_predicate(predicate_name)
 
-    sv = sjoin(handle, predicate,
-               <GEOSGeometry*> left.data, left.size,
-               <GEOSGeometry*> right.data, right.size)
+    with nogil:
+        sv = sjoin(handle, predicate,
+                   <GEOSGeometry*> left.data, left_size,
+                   <GEOSGeometry*> right.data, right_size)
 
     out = np.empty((sv.n // 2, 2), dtype=np.uintp)
 
-    for idx in range(0, sv.n // 2):
-        out[idx, 0] = sv.a[2 * idx]
-        out[idx, 1] = sv.a[2 * idx + 1]
+    with nogil:
+        for idx in range(0, sv.n // 2):
+            out[idx, 0] = sv.a[2 * idx]
+            out[idx, 1] = sv.a[2 * idx + 1]
 
     cfree(sv.a)
     return out

--- a/geopandas/vectorized.pyx
+++ b/geopandas/vectorized.pyx
@@ -26,12 +26,15 @@ cdef extern from "algos.h":
     ctypedef char (*GEOSPredicate)(GEOSContextHandle_t handler,
                                    const GEOSGeometry *left,
                                    const GEOSGeometry *right) nogil
+    ctypedef char (*GEOSPreparedPredicate)(GEOSContextHandle_t handler,
+                                           const GEOSPreparedGeometry *left,
+                                           const GEOSGeometry *right) nogil
     ctypedef struct size_vector:
         size_t n
         size_t m
         size_t *a
     size_vector sjoin(GEOSContextHandle_t handle,
-                      GEOSPredicate predicate,
+                      GEOSPreparedPredicate predicate,
                       GEOSGeometry *left, size_t nleft,
                       GEOSGeometry *right, size_t nright) nogil
 
@@ -91,6 +94,7 @@ cdef prepared_binary_predicate(str op,
     cdef GEOSGeometry *geom
     cdef GEOSGeometry *other_geom
     cdef GEOSPreparedGeometry *prepared_geom
+    cdef GEOSPreparedPredicate predicate
     cdef unsigned int n = geoms.size
 
     cdef np.ndarray[np.uint8_t, ndim=1, cast=True] out = np.empty(n, dtype=np.bool_)
@@ -107,6 +111,19 @@ cdef prepared_binary_predicate(str op,
     geos_handle = get_geos_context_handle()
     prepared_geom = geos_from_prepared(other)
 
+    predicate = get_prepared_predicate(op)
+
+    with nogil:
+        for idx in xrange(n):
+            geom = <GEOSGeometry *> geoms[idx]
+            if geom != NULL:
+                out[idx] = predicate(handle, prepared_geom, geom)
+            else:
+                out[idx] = 0
+
+    return out
+
+cdef GEOSPreparedPredicate get_prepared_predicate(str op):
     if op == 'contains':
         func = GEOSPreparedContains_r
     elif op == 'disjoint':
@@ -130,15 +147,7 @@ cdef prepared_binary_predicate(str op,
     else:
         raise NotImplementedError(op)
 
-    with nogil:
-        for idx in xrange(n):
-            geom = <GEOSGeometry *> geoms[idx]
-            if geom != NULL:
-                out[idx] = func(handle, prepared_geom, geom)
-            else:
-                out[idx] = 0
-
-    return out
+    return func
 
 
 cdef GEOSPredicate get_predicate(str op):
@@ -794,7 +803,7 @@ cpdef cysjoin(np.ndarray[np.uintp_t, ndim=1, cast=True] left,
               np.ndarray[np.uintp_t, ndim=1, cast=True] right,
               str predicate_name):
     cdef GEOSContextHandle_t handle
-    cdef GEOSPredicate predicate
+    cdef GEOSPreparedPredicate predicate
     cdef size_vector sv
     cdef Py_ssize_t idx
     cdef np.ndarray[np.uintp_t, ndim=2] out
@@ -802,7 +811,7 @@ cpdef cysjoin(np.ndarray[np.uintp_t, ndim=1, cast=True] left,
     cdef size_t right_size = right.size
 
     handle = get_geos_context_handle()
-    predicate = get_predicate(predicate_name)
+    predicate = get_prepared_predicate(predicate_name)
 
     with nogil:
         sv = sjoin(handle, predicate,


### PR DESCRIPTION
This adds a spatial join operation using the STRTree in GEOS.  All of the logic in implemented in C.  I had to add in the kvec.h library for dynamic arrays.

### Example

```python
In [1]: from geopandas.vectorized import VectorizedGeometry
   ...: from geopandas.vectorized import VectorizedGeometry, from_shapely, points_from_xy
   ...: import numpy as np
   ...: x = np.random.random(1000); y = np.random.random(1000)
   ...: import random
   ...: import shapely.geometry
   ...: triangles = [shapely.geometry.Polygon([(random.random(), random.random())
   ...:                                            for i in range(3)])
   ...:                  for _ in range(1000)]
   ...: T = from_shapely(triangles)
   ...: P = points_from_xy(x, y)
   ...: T
   ...: P
   ...: from geopandas.vectorized import VectorizedGeometry, from_shapely, points_from_xy, cysjoin
   ...: %time out = cysjoin(T.data, P.data, 'contains')
   ...: 
CPU times: user 3.32 s, sys: 12 ms, total: 3.33 s
Wall time: 3.34 s

In [2]: %load_ext ptime

In [3]: %ptime -n 4 out = cysjoin(T.data, P.data, 'contains')
Total serial time:   13.12 s
Total parallel time: 5.61 s
For a 2.34X speedup across 4 threads
```

I don't know yet if this is fast or slow.  It's an odd benchmark because most of the triangles overlap.  Also, should we be using preprared geometries for things like this?